### PR TITLE
Convert some text files to UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ URI.js weighs in at only 2.3kb (gzipped, 7kb deflated). Need IRI support? It's o
 ### IRI Support
 
 	//convert IRI to URI
-	URI.serialize(URI.parse("http://examplé.org/rosé")) === "http://xn--exampl-gva.org/ros%C3%A9"
+	URI.serialize(URI.parse("http://examplÃ©.org/rosÃ©")) === "http://xn--exampl-gva.org/ros%C3%A9"
 	//convert URI to IRI
-	URI.serialize(URI.parse("http://xn--exampl-gva.org/ros%C3%A9"), {iri:true}) === "http://examplé.org/rosé"
+	URI.serialize(URI.parse("http://xn--exampl-gva.org/ros%C3%A9"), {iri:true}) === "http://examplÃ©.org/rosÃ©"
 
 ### Options
 

--- a/tests/qunit.js
+++ b/tests/qunit.js
@@ -3,7 +3,7 @@
  * 
  * http://docs.jquery.com/QUnit
  *
- * Copyright (c) 2009 John Resig, Jörn Zaefferer
+ * Copyright (c) 2009 John Resig, JÃ¶rn Zaefferer
  * Dual licensed under the MIT (MIT-LICENSE.txt)
  * and GPL (GPL-LICENSE.txt) licenses.
  */
@@ -674,7 +674,7 @@ function id(name) {
 // Test for equality any JavaScript type.
 // Discussions and reference: http://philrathe.com/articles/equiv
 // Test suites: http://philrathe.com/tests/equiv
-// Author: Philippe Rathé <prathe@gmail.com>
+// Author: Philippe RathÃ© <prathe@gmail.com>
 QUnit.equiv = function () {
 
     var innerEquiv; // the real equiv function


### PR DESCRIPTION
If you look at this page, you can spot some mojibake:

https://www.npmjs.com/package/uri-js#iri-support

This is because npmjs.com expects the README file to be in UTF-8. UTF-8 is a sensible choice nowadays for all text files, so I converted the text files to that.