### PR TITLE
Don't use esnext for module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An RFC 3986/3987 compliant, scheme extendable URI/IRI parsing/validating/resolving library for JavaScript.",
   "main": "dist/es5/uri.all.js",
   "types": "dist/es5/uri.all.d.ts",
-  "module": "dist/esnext/index.js",
+  "module": "dist/es5/uri.all.js",
+  "jsnext:main": "dist/esnext/index.js",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
Webpack doesn't support es6+ yet.

I don't know what the right thing to do is but I think module shouldn't yet use es6. 