### PR TITLE
fix: Add files property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "directories": {
     "test": "tests"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build:esnext": "node_modules/.bin/tsc",
     "build:es5": "node_modules/.bin/rollup -c && cp dist/esnext/uri.d.ts dist/es5/uri.all.d.ts && npm run build:es5:fix-sourcemap",


### PR DESCRIPTION
This PR will add the `files` property to `package.json` to tell npm not to publish test files or `tsconfig.json`.

Before: 7 directories, 57 files
After: 4 directories, 38 files
