### PR TITLE
fix: Remove unnecessary node_modules path

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "test": "tests"
   },
   "scripts": {
-    "build:esnext": "node_modules/.bin/tsc",
-    "build:es5": "node_modules/.bin/rollup -c && cp dist/esnext/uri.d.ts dist/es5/uri.all.d.ts && npm run build:es5:fix-sourcemap",
-    "build:es5:fix-sourcemap": "node_modules/.bin/sorcery -i dist/es5/uri.all.js",
-    "build:es5:min": "node_modules/.bin/uglifyjs dist/es5/uri.all.js --support-ie8 --output dist/es5/uri.all.min.js --in-source-map dist/es5/uri.all.js.map --source-map uri.all.min.js.map --comments --compress --mangle --pure-funcs merge subexp  && mv uri.all.min.js.map dist/es5/ && cp dist/es5/uri.all.d.ts dist/es5/uri.all.min.d.ts",
+    "build:esnext": "tsc",
+    "build:es5": "rollup -c && cp dist/esnext/uri.d.ts dist/es5/uri.all.d.ts && npm run build:es5:fix-sourcemap",
+    "build:es5:fix-sourcemap": "sorcery -i dist/es5/uri.all.js",
+    "build:es5:min": "uglifyjs dist/es5/uri.all.js --support-ie8 --output dist/es5/uri.all.min.js --in-source-map dist/es5/uri.all.js.map --source-map uri.all.min.js.map --comments --compress --mangle --pure-funcs merge subexp && mv uri.all.min.js.map dist/es5/ && cp dist/es5/uri.all.d.ts dist/es5/uri.all.min.d.ts",
     "build": "npm run build:esnext && npm run build:es5 && npm run build:es5:min",
-    "test": "node_modules/.bin/mocha -u mocha-qunit-ui dist/es5/uri.all.js tests/tests.js"
+    "test": "mocha -u mocha-qunit-ui dist/es5/uri.all.js tests/tests.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR will remove `node_modules` from the scripts as npm will resolve these paths itself.