### PR TITLE
Speed improvements

### DIFF
--- a/src/uri.ts
+++ b/src/uri.ts
@@ -157,7 +157,7 @@ function _normalizeComponentEncoding(components:URIComponents, protocol:URIRegEx
 };
 
 function _stripLeadingZeros(str:string, token:string, outputArray=false) : string | string[] {
-	const outArray:string[]=[];
+	const outArray:string[] = [];
 	let out = ''
 	let temp = ''
 	let skip = true
@@ -183,11 +183,11 @@ function _stripLeadingZeros(str:string, token:string, outputArray=false) : strin
 			} else {
 				skip = false
 			}
-			if(outputArray) {
-				if(c !== token) {
+			if (outputArray) {
+				if (c !== token) {
 				temp+=c
 				}
-			}else{
+			} else {
 				out += c
 			}
 		}


### PR DESCRIPTION
This PR addresses some of the slowness in: https://github.com/garycourt/uri-js/issues/40

- Replaced the regex to strip leadingZeros with a proper function
- Added skips in normalizeIP v4 & v6 if the bases tokens are not found. It avoids running the regex for most of the `uri` we will try.

Done a test file and a benchmark file.
test file
```js
const evalStart = process.hrtime();
var URI = require("./dist/es5/uri.all");
const evalEnd = process.hrtime(evalStart);
const NS_PER_SEC = 1e9;
function readableHRTimeMs(diff) {
  if (diff.length) return (diff[0] * NS_PER_SEC + diff[1]) / 1000000;
  else {
    return 0;
  }
}
const coldStart = process.hrtime();
URI.parse("http://abc.com/~smith/home.html");
const coldEnd = process.hrtime(coldStart);
const warmStart = process.hrtime();
URI.parse("http://abc.com/~smith/home.html");
const warmEnd = process.hrtime(warmStart);
console.log("evalEnd", readableHRTimeMs(evalEnd),'ms')
console.log("coldEnd", readableHRTimeMs(coldEnd), "ms");
console.log("warmEnd", readableHRTimeMs(warmEnd), "ms");

```
benchmark
```js
const benchmark = require("benchmark");
const suite = new benchmark.Suite();
var URI = require("./dist/es5/uri.all");
URI.parse("https://example.com");

suite.add("uri", function () {
  URI.parse("https://example.com");
});
suite.add("IPv4", function () {
    URI.parse("//10.10.10.10");
});
suite.add("IPv6", function () {
    URI.parse("//[2001:db8::7]");
});

suite.on("cycle", cycle);

suite.run();

function cycle(e) {
  console.log(e.target.toString());
}

```
Results:
```
Branch
uri x 310,409 ops/sec ±0.27% (93 runs sampled)
IPv4 x 508,330 ops/sec ±0.24% (93 runs sampled)
IPv6 x 234,350 ops/sec ±0.54% (94 runs sampled)
Test file :
evalEnd 3.2675 ms
coldEnd 0.8562 ms
warmEnd 0.1371 ms

Master
uri x 280,779 ops/sec ±0.22% (94 runs sampled)
IPv4 x 227,370 ops/sec ±0.47% (92 runs sampled)
IPv6 x 162,507 ops/sec ±0.26% (95 runs sampled)
Test file :
evalEnd 2.9539 ms
coldEnd 7.7863 ms
warmEnd 2.8647 ms
```

All suggestions are welcome.