### PR TITLE
Remove `yarn.lock` from publish files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "files": [
     "dist",
     "package.json",
-    "yarn.lock",
     "README.md",
     "CHANGELOG",
     "LICENSE"


### PR DESCRIPTION
This was already ignored in `.npmignore` but was still published to npm due to `files` in package.json