### PR TITLE
Fix Prototype Pollution in minimist

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1696,9 +1696,9 @@ minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mixin-deep@^1.2.0:
   version "1.3.2"


### PR DESCRIPTION
## Describe the bugs: 🐛
Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).
A vulnerability was found in Minimist up to 1.2.5. It has been declared as critical. Affected by this vulnerability is the function setKey of the file index.js. The manipulation with an unknown input leads to a privilege escalation vulnerability. The CWE definition for the vulnerability is CWE-94. The software constructs all or part of a code segment using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the syntax or behavior of the intended code segment. The impact remains unknown.

**How did the [CVE-2021-44906](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44906) vulnerability occur?**
occurrence of this vulnerability in repository or project code that has the version ie "minimist": "^1.2.5" A vulnerability was found in Minimist up to 1.2.5. Has been declared critical. Affected by this vulnerability is the setKey function of the index.js file. Manipulation with unknown input leads to a privilege escalation vulnerability. The CWE definition of vulnerability is [CWE-94](https://cwe.mitre.org/data/definitions/94.html). The software constructs all or part of a code segment using externally influenced input from upstream components, but does not neutralize or incorrectly neutralize special elements that could change the syntax or behavior of the intended code segment.

**POC :**
```js
require('minimist')('--_.constructor.constructor.prototype.foo bar'.split(' ')); console.log((function(){}).foo); // bar
```
## Vulnerabilities Details:
Prototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution. There are two main ways in which the pollution of prototypes occurs:
  * Unsafe `Object` recursive merge
  * Property definition by path

Unsafe Object recursive merge The logic of a vulnerable recursive merge function follows the following high-level model:
```
merge (target, source)
foreach property of source

if property exists and is an object on both the target and the source merge(target[property], source[property]) else target[property] = source[property]
```
When the source object contains a property named proto defined with Object.defineProperty() , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of Object and the source of Object as defined by the attacker. Properties are then copied on the Object prototype. Clone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: merge({},source). lodash and Hoek are libraries susceptible to recursive merge attacks.


GHSA-xvch-5gv4-984h
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`
**CVE-2021-44906**

